### PR TITLE
Force darkmode

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -20,7 +20,11 @@ const config: DocsThemeConfig = {
 
   primaryHue: { dark: 33, light: 33 },
   feedback: {
-    content: null
+    content: null,
+  },
+  darkMode: false,
+  nextThemes: {
+    defaultTheme: "dark",
   },
 };
 


### PR DESCRIPTION
Designers suggested to force dark mode so that we don't need to setup color schemes and design icons and logo's twice.