### PR TITLE
fix: recommended OS versions + storage callout

### DIFF
--- a/pages/nodes/requirements.mdx
+++ b/pages/nodes/requirements.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 ---
 description: "Validators play a critical role in maintaining the security and performance of the Beam Network. With the Horizon upgrade, these requirements ensure network decentralization and security."
 ---

--- a/pages/nodes/requirements.mdx
+++ b/pages/nodes/requirements.mdx
@@ -22,10 +22,14 @@ Avalanche, and therefore the Beam Network too, is an incredibly lightweight prot
 - **CPU:** Equivalent of 8 AWS vCPU
 - **RAM:** 16 GiB
 - **Storage:** 1 TiB
-- **OS:** Ubuntu 20.04 or MacOS >= 12
+- **OS:** Ubuntu 22.04 or later, or macOS 13 or later.
 - **Network:** sustained 5Mbps up/down bandwidth
 
 The node should be configured to accept incoming TCP/IP connections on port `9651`.
+
+<Callout type="info">
+  As of the time of writing, the Beam L1 consumes approximately 50GB of storage.
+</Callout>
 
 ## Continuous Fee
 


### PR DESCRIPTION
It should be clear that the system should work for systems later than Ubuntu 20.04. Ubuntu 20.04 will reach its end-of-support next month, and we want to avoid the hassle of having to upgrade OS. The same goes for MacOS 12 (has reached its end-of-support late last year)