### PR TITLE
feat: introduce easy-install script, vm alias file

### DIFF
--- a/pages/nodes/run_node/method2.mdx
+++ b/pages/nodes/run_node/method2.mdx
@@ -1,13 +1,23 @@
 import { Callout, Steps } from "nextra/components";
 
 
-## Method 2: Setting up an Avalanchego node via Docker
+## Method 2: Setting up an AvalancheGo node via Docker
+
+## ⚡ Easy Install (Recommended)
+
+The fastest way to set up your node:
+
+```bash
+curl -fsSL https://docs.onbeam.com/scripts/docker-setup-beam-validator.sh -o docker-setup-beam-validator.sh && chmod +x docker-setup-beam-validator.sh && ./docker-setup-beam-validator.sh
+```
+
+The script assumes that you have Docker and Docker Compose installed. You can re-run this anytime to apply future updates (new image tags, upgrade configs, etc.). If you're using this script, you can skip the manual steps below.
 
 <Steps>
 
-### Make sure you have Docker installed and running on your system
+### Make sure you have Docker and `curl` installed and running on your system
 
-### Apply Network Upgrades
+### Apply network upgrades
 
 Create the config directory for Beam and download the `upgrade.json` file from GitHub. Place it in the appropriate directory.
 
@@ -17,16 +27,22 @@ You might need to use `sudo` to elevate your privileges if `mkdir` fails. If you
 mkdir -p ~/.avalanchego/configs/chains/2tmrrBo1Lgt1mzzvPSFt73kkQKFas5d1AP88tv9cicwoFp8BSn
 cd ~/.avalanchego/configs/chains/2tmrrBo1Lgt1mzzvPSFt73kkQKFas5d1AP88tv9cicwoFp8BSn
 
-wget https://raw.githubusercontent.com/BuildOnBeam/beam-subnet/main/subnets/beam-mainnet/upgrade.json
+wget -O upgrade.json https://raw.githubusercontent.com/BuildOnBeam/beam-subnet/main/subnets/beam-mainnet/upgrade.json
 ```
 
-### Prepare and run Docker image
+### Set up VM alias mapping
 
-Head over to: [build.avax.network](https://build.avax.network/tools/l1-toolbox#avalanchegoDocker). This website will help you pre-configure a Docker container that runs your node against a specific network (as specified by the Subnet ID). 
+```bash
+mkdir -p ~/.avalanchego/configs/vms
 
-Make sure to input the correct L1 Subnet ID in the textbox: *"eYwmVU67LmSfZb1RwqCMhBYkFyG8ftxn6jAwqzFmxC9STBWLC"*. Once done, copy the code from the *"Node Command"* field and paste it into your command line terminal.
+cat > ~/.avalanchego/configs/vms/aliases.json <<EOF
+{
+  "kLPs8zGsTVZ28DhP1VefPCFbCgS7o5bDNez8JUxPVw9E6Ubbz": ["srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"]
+}
+EOF
+```
 
-Example code:
+### Run Docker image
 ```bash
 docker run -it -d \
     --name avago \
@@ -37,13 +53,11 @@ docker run -it -d \
     -e AVAGO_HTTP_HOST=0.0.0.0 \
     -e AVAGO_TRACK_SUBNETS=eYwmVU67LmSfZb1RwqCMhBYkFyG8ftxn6jAwqzFmxC9STBWLC \
     -e VM_ID=kLPs8zGsTVZ28DhP1VefPCFbCgS7o5bDNez8JUxPVw9E6Ubbz \
-    --entrypoint /bin/sh \
-    avaplatform/subnet-evm:v0.7.3 \
-    -c "if ! [ -e /avalanchego/build/plugins/kLPs8zGsTVZ28DhP1VefPCFbCgS7o5bDNez8JUxPVw9E6Ubbz ]; then echo 'Renamed subnet-evm to Beam mainnet' && mv /avalanchego/build/plugins/* /avalanchego/build/plugins/kLPs8zGsTVZ28DhP1VefPCFbCgS7o5bDNez8JUxPVw9E6Ubbz; fi && /avalanchego/build/avalanchego"
+    avaplatform/subnet-evm:v0.7.3
 ```
 
 </Steps>
 
 <br/>
 
-Once your Beam Node is properly set up, head over to [register a validator](/nodes/run_node/register).
+Once your Beam Node is properly set up and has completed bootstrapping, head over to [register a validator](/nodes/run_node/register).


### PR DESCRIPTION
- linked the install script from #246
- fixed header casing
- made sure wget of upgrade file always overwrites (and not create a new file with `<file-name>.1`, for example)
- removed avax build link - this confuses a lot of people and they also haven't fixed the builder wherein it defaults to connecting to fuji.
- introduced vm alias mapping file
- custom entrypoint is not necessary because of the above