### PR TITLE
Update avax toolbox URL for getting the p-chain address

### DIFF
--- a/pages/nodes/run_node/register.mdx
+++ b/pages/nodes/run_node/register.mdx
@@ -18,7 +18,7 @@ Registering a running node as a Validator consists of 2 steps:
 
 Since we are setting up an Avalanche node there is a requirement to fill in the P-Chain address. This address won't be visible in any other wallet besides the Avalanche Core wallet. You can get it installed as a Chrome extension: [Core wallet](https://chromewebstore.google.com/detail/core-crypto-wallet-nft-ex/agoakfejjabomempkjlepdflaleeobhb?utm_source=ext_app_menu)
 
-Once your wallet is set up and restored in Core, the easiest way to find your P-Chain address is by visiting the Avalanche toolchain website and connecting with Core. Go to this page: [build.avax.network](https://build.avax.network/tools/l1-toolbox#getPChainAddress) and it will display your P-Chain address at the top. Make sure you selected *"Mainnet"* as the network.
+Once your wallet is set up and restored in Core, the easiest way to find your P-Chain address is by visiting the Avalanche toolchain website and connecting with Core. Go to this page: [build.avax.network](https://build.avax.network/tools/l1-toolbox) and it will display your P-Chain address at the top. Make sure you selected *"Mainnet"* as the network.
 
 The second part of the preparation is by getting the required parameters from your running node:
 - Node ID


### PR DESCRIPTION
Note: Old URL is not working.