### PR TITLE
Add Envio to chain resources

### DIFF
--- a/pages/chain/resources.mdx
+++ b/pages/chain/resources.mdx
@@ -8,6 +8,7 @@ import { Cards } from 'nextra/components'
  
 </Cards>
 
+- [Envio](https://envio.dev/?utm_source=beam&utm_medium=partner-docs) is the data layer for blockchain apps, giving Beam developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
 - [Beam Testnet Faucet](https://core.app/tools/testnet-faucet/?subnet=beam&token=beam) ([Alternative Faucet](https://faucet.onbeam.com/)): A testnet faucet for obtaining BEAM for testing purposes on the Beam Testnet.
 - [Verify Contract](https://subnets.avax.network/tools/verify-contract): A tool for verifying smart contracts on the official block explorer.
 - [Avatools](https://avatools.io): Offers helpful tools for interacting with the Beam Subnet, such as converting hex to cb58.


### PR DESCRIPTION
Adds Envio to the developer resources list. Envio's HyperIndex natively supports indexing any EVM chain out of the box, including Beam, using your own RPC as the data source.